### PR TITLE
Fix: validate brain ownership on item creation

### DIFF
--- a/src/helpers/items.helpers.ts
+++ b/src/helpers/items.helpers.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyRequest } from "fastify";
 import { AppError } from "../util/appError";
 import { CreateItemBody } from "../routes/item";
+import { isEmpty } from "./commons";
 import z from "zod";
 
 
@@ -83,6 +84,16 @@ export async function createTweetItemHelper(
   const { id } = req.user;
   const { title,content,tags,url,brainId,pinned } = req.body as z.infer<typeof CreateItemBody>;
 
+  // Verify that the target brain belongs to the requesting user
+  const brain = await trx
+    .table("brains")
+    .where({ id: brainId, owner_id: id })
+    .first("id");
+
+  if (isEmpty(brain)) {
+    throw AppError.notFound("BE-10", "Brain not found");
+  }
+
   // Try to fetch oEmbed metadata for the tweet URL if present
   const metadata = await getXMetadata(url);
 
@@ -132,6 +143,10 @@ export async function createTweetItemHelper(
     console.log(err);
 
     await trx.rollback();
+
+    if (err instanceof AppError) {
+      throw err;
+    }
 
     throw AppError.internal("BE-Internal", "Something Went Wrong");
   }


### PR DESCRIPTION
## Summary
- validate brain ownership before inserting tweet items
- propagate AppErrors instead of always returning 500

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70477c478833282d4109c90bc8576